### PR TITLE
Update admin.rb

### DIFF
--- a/lib/motor/admin.rb
+++ b/lib/motor/admin.rb
@@ -103,8 +103,6 @@ module Motor
           puts
           puts '  => Run `rails g motor:install && rake db:migrate` in order to create Motor Admin configuration tables'
           puts
-
-          raise
         end
 
         unless Motor::ApiConfig.table_exists?
@@ -112,8 +110,6 @@ module Motor
           puts '  => Run `rails g motor:upgrade && rake db:migrate`' \
                ' to perform data migration and enable the latest features'
           puts
-
-          raise
         end
       end
     end


### PR DESCRIPTION
Remove raise exception when table is not exists to pass db:migrate rake task on rails 6